### PR TITLE
CEP-1276 fix for very short long description

### DIFF
--- a/templates/culturefeed-actor.tpl.php
+++ b/templates/culturefeed-actor.tpl.php
@@ -9,11 +9,21 @@
 
   <div class="col-sm-8">
 
-    <?php if (!empty($shortdescription)) : ?>
-      <p>
-        <?php print $shortdescription; ?>
-      </p>
-    <?php endif; ?>
+    <p>
+      <?php if (!empty($shortdescription)): ?>
+        <div class="short-description">
+          <?php print $shortdescription; ?>
+        </div>
+        <?php if (!empty($longdescription)): ?>
+          <div class="long-description">
+            <div id="cf-longdescription" class="collapse collapse-in"><?php print $longdescription; ?></div>
+            <?php print l(t('Read more'), '', $readmore_options) ?>
+          </div>
+        <?php endif; ?>
+      <?php else: ?>
+        <?php print $longdescription; ?>
+      <?php endif; ?>
+    </p>
 
     <table class="table table-condended detail-table">
       <tbody>

--- a/templates/culturefeed-event.tpl.php
+++ b/templates/culturefeed-event.tpl.php
@@ -24,10 +24,18 @@
     <?php endif; ?>
 
     <p>
-      <?php print $shortdescription; ?>
-      <?php if (!empty($longdescription)): ?>
-        <?php print l(t('Read more'), '', $readmore_options) ?>
-        <div id="cf-longdescription" class="collapse collapse-in"><?php print $longdescription; ?></div>
+      <?php if (!empty($shortdescription)): ?>
+        <div class="short-description">
+          <?php print $shortdescription; ?>
+        </div>
+        <?php if (!empty($longdescription)): ?>
+          <div class="long-description">
+            <div id="cf-longdescription" class="collapse collapse-in"><?php print $longdescription; ?></div>
+            <?php print l(t('Read more'), '', $readmore_options) ?>
+          </div>
+        <?php endif; ?>
+      <?php else: ?>
+        <?php print $longdescription; ?>
       <?php endif; ?>
     </p>
 

--- a/templates/culturefeed-production.tpl.php
+++ b/templates/culturefeed-production.tpl.php
@@ -23,10 +23,18 @@
     <?php endif; ?>
 
     <p>
-      <?php print $shortdescription; ?>
-      <?php if (!empty($longdescription)): ?>
-        <?php print l(t('Read more'), '', $read_more_options) ?>
-        <div id="cf-longdescription" class="collapse collapse-in"><?php print $longdescription; ?></div>
+      <?php if (!empty($shortdescription)): ?>
+        <div class="short-description">
+          <?php print $shortdescription; ?>
+        </div>
+        <?php if (!empty($longdescription)): ?>
+          <div class="long-description">
+            <div id="cf-longdescription" class="collapse collapse-in"><?php print $longdescription; ?></div>
+            <?php print l(t('Read more'), '', $readmore_options) ?>
+          </div>
+        <?php endif; ?>
+      <?php else: ?>
+        <?php print $longdescription; ?>
       <?php endif; ?>
     </p>
 


### PR DESCRIPTION
make deduplication of short and long description work for single paragraph descriptions
example: http://www.cultuurkuur.be/agenda/e/open-klas/5caeb10e-913b-41bb-89c0-d934ca1c6b31